### PR TITLE
Allow 192.168.1.56 for LAN login testing

### DIFF
--- a/docs/AUTH_SETUP.md
+++ b/docs/AUTH_SETUP.md
@@ -46,6 +46,11 @@ For Google sign-in, the domain hosting the app must be in
 Vercel domains are usually added automatically; add custom domains manually.
 Use the bare host only (e.g. `localhost`, not `http://localhost:3000`).
 
+**LAN login testing (temporary):** `192.168.1.56` is listed in `firebase.json`
+(`auth.authorizedDomains`) and Next.js `allowedDevOrigins` so you can open
+`http://192.168.1.56:3000` on the local network. Also add that host in the
+Firebase console if deploy does not pick it up. Remove it when testing is done.
+
 ## 5. Run the app
 
 ```bash

--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,23 @@
 {
+  "auth": {
+    "providers": {
+      "emailPassword": true,
+      "googleSignIn": {
+        "oAuthBrandDisplayName": "Budgety",
+        "supportEmail": "support@budgety.app",
+        "authorizedRedirectUris": [
+          "https://budgety-woad.vercel.app",
+          "http://192.168.1.56:3000"
+        ]
+      }
+    },
+    "authorizedDomains": [
+      "localhost",
+      "192.168.1.56",
+      "budgety-woad.vercel.app",
+      "budgety-e7e94.firebaseapp.com"
+    ]
+  },
   "emulators": {
     "auth": {
       "host": "127.0.0.1",

--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,8 @@ const nextConfig = {
   turbopack: {
     resolveExtensions: [".js", ".jsx", ".json"],
   },
+  // Temporary: allow LAN IP for login testing on the local network
+  allowedDevOrigins: ["192.168.1.56"],
 };
 
 export default nextConfig;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the local network IP `192.168.1.56` so Firebase Auth / Google sign-in and Next.js can be tested from another device on the LAN at `http://192.168.1.56:3000`.

### Changes
- `firebase.json` — add `192.168.1.56` to `auth.authorizedDomains` and `http://192.168.1.56:3000` to Google redirect URIs
- `next.config.js` — `allowedDevOrigins: ["192.168.1.56"]`
- `docs/AUTH_SETUP.md` — note that this is temporary LAN testing config

### After merge
Deploy auth config (`npm run firebase:deploy-auth` or console) and confirm the domain appears under **Authentication → Settings → Authorized domains**. Remove the IP when LAN testing is done.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f898c-5175-7c75-8fa9-94119eb368c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f898c-5175-7c75-8fa9-94119eb368c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

