### PR TITLE
fix: time-based dashboard greeting and date-only subtitle

### DIFF
--- a/src/components/screens/dashboard/DashboardScreen.tsx
+++ b/src/components/screens/dashboard/DashboardScreen.tsx
@@ -19,6 +19,7 @@ import { useAppNavigation } from "@hooks/useAppNavigation";
 import { useCurrencyFormatter } from "@hooks/useCurrencyFormatter";
 import { useAppSelector } from "@store/hooks";
 import { selectPeriodAggregates } from "@store/selectors/periodSelectors";
+import { formatHeaderToday, getTimeOfDayGreeting } from "@utils/dateUtils";
 
 function daysUntil(dueDate: string): number | null {
   const due = new Date(dueDate);
@@ -89,14 +90,11 @@ export function DashboardScreen() {
       .slice(0, DISPLAY_LIMITS.PREVIEW_ITEMS);
   }, [bills]);
 
-  const firstName = user?.displayName?.split(" ")[0] || user?.email?.split("@")[0] || "there";
+  const firstName =
+    user?.displayName?.split(" ")[0] || user?.email?.split("@")[0] || UI_TEXT.GREETING_NAME_FALLBACK;
   const initial = firstName.charAt(0).toUpperCase();
-  const todayLabel = new Date().toLocaleDateString("en-GB", {
-    weekday: "short",
-    day: "numeric",
-    month: "long",
-    year: "numeric",
-  });
+  const greeting = getTimeOfDayGreeting();
+  const todayLabel = formatHeaderToday();
 
   return (
     <div className="mx-auto max-w-2xl space-y-4 md:max-w-6xl md:space-y-5 lg:max-w-7xl">
@@ -112,8 +110,10 @@ export function DashboardScreen() {
             )}
           </span>
           <div className="min-w-0">
-            <h1 className="truncate text-xl font-bold tracking-tight text-brand-deep">Good morning, {firstName}</h1>
-            <p className="truncate text-sm text-gray-400">Here is your wealth summary · {todayLabel}</p>
+            <h1 className="truncate text-xl font-bold tracking-tight text-brand-deep">
+              {greeting}, {firstName}
+            </h1>
+            <p className="truncate text-sm text-gray-400">{todayLabel}</p>
           </div>
         </div>
         <button

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -625,6 +625,10 @@ export const UI_TEXT = {
   SAVINGS_RATE: "Savings Rate",
   RECENT_TRANSACTIONS: "Recent Transactions",
   DASHBOARD: "Dashboard",
+  GREETING_MORNING: "Good morning",
+  GREETING_AFTERNOON: "Good afternoon",
+  GREETING_EVENING: "Good evening",
+  GREETING_NAME_FALLBACK: "there",
   HOME: "Home",
   TRANSACTION: "Transaction",
   ANALYTICS: "Analytics",
@@ -1262,6 +1266,8 @@ export const DATE_FORMAT = "DD-MM-YYYY";
 export const DATE_FORMAT_LONG = "DD-MMM-YYYY hh:mm A";
 /** Short month + day for list rows (e.g. Oct 12) */
 export const DATE_FORMAT_MONTH_DAY = "MMM D";
+/** Header “today” label, e.g. Sat, 25 July 2026 */
+export const DATE_FORMAT_HEADER_TODAY = "ddd, D MMMM YYYY";
 /** ISO 8601 date-only for DB DATE columns (YYYY-MM-DD) */
 export const DATE_FORMAT_STORAGE = "YYYY-MM-DD";
 
@@ -1366,6 +1372,10 @@ export const DATE_CONSTANTS = {
   MAX_REMINDER_DAYS: 30,
   /** Window used by Bills sticky summary / Pay Selected. */
   BILLS_DUE_WINDOW_DAYS: 7,
+  /** Local hour (0–23) when “Good morning” ends (exclusive). */
+  GREETING_MORNING_END_HOUR: 12,
+  /** Local hour (0–23) when “Good afternoon” ends (exclusive). */
+  GREETING_AFTERNOON_END_HOUR: 17,
 };
 
 // Number Formatting

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -5,7 +5,13 @@
 import dayjs, { type Dayjs } from "dayjs";
 import customParseFormat from "dayjs/plugin/customParseFormat";
 
-import { DATE_FORMAT, DATE_FORMAT_STORAGE, UI_TEXT } from "@constants";
+import {
+  DATE_CONSTANTS,
+  DATE_FORMAT,
+  DATE_FORMAT_HEADER_TODAY,
+  DATE_FORMAT_STORAGE,
+  UI_TEXT,
+} from "@constants";
 
 dayjs.extend(customParseFormat);
 
@@ -180,6 +186,23 @@ export function compareByDateThenCreatedAt(a: DateSortable, b: DateSortable): nu
   const cmp = compareDates(a.date || a.createdAt, b.date || b.createdAt);
   if (cmp !== 0) return cmp;
   return dayjs(a.createdAt || a.date).valueOf() - dayjs(b.createdAt || b.date).valueOf();
+}
+
+/**
+ * Time-of-day greeting based on the local clock (morning / afternoon / evening).
+ */
+export function getTimeOfDayGreeting(now: Dayjs = dayjs()): string {
+  const hour = now.hour();
+  if (hour < DATE_CONSTANTS.GREETING_MORNING_END_HOUR) return UI_TEXT.GREETING_MORNING;
+  if (hour < DATE_CONSTANTS.GREETING_AFTERNOON_END_HOUR) return UI_TEXT.GREETING_AFTERNOON;
+  return UI_TEXT.GREETING_EVENING;
+}
+
+/**
+ * Today’s date for dashboard/header display (e.g. Sat, 25 July 2026).
+ */
+export function formatHeaderToday(now: Dayjs = dayjs()): string {
+  return now.format(DATE_FORMAT_HEADER_TODAY);
 }
 
 /**


### PR DESCRIPTION
Show Good morning/afternoon/evening from the local clock, and drop the wealth summary copy so the header subtitle is just today’s date.